### PR TITLE
[hotfix->main]31 レシピ一覧画面のデグレ修正, readme修正, UserSeederの修正, テストが失敗した際にテストを中止するコマンドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## 開発環境
 
-```
+```bash
 $ php artisan -V
 Laravel Framework 10.23.1
 
@@ -33,23 +33,23 @@ vscodeでdockerコンテナー内での作業するための環境を構築す�
 
 wsl ubuntuのhomeディレクトリ
 
-```
+```bash
 git clone https://github.com/ykabayama/what-for-dinner.git
 ```
 
-```
+```bash
 cd what-for-dinner
 ```
 
 ### 2. envファイルの準備
 
-```
+```bash
 cp .env.example .env
 ```
 
 ### 3. vender等のインストール
 
-```
+```bash
 docker run --rm \
     -u "$(id -u):$(id -g)" \
     -v "$(pwd):/var/www/html" \
@@ -60,12 +60,12 @@ docker run --rm \
 
 ### 4. コンテナ立ち上げ
 
-```
+```bash
 ./vendor/bin/sail up -d
 ```
 
 またはエイリアスを登録している場合は下記
-```
+```bash
 sail up -d
 ```
 
@@ -73,12 +73,12 @@ sail up -d
 
 プロジェクトルート上で (`~/what-for-dinner`)
 
-```
+```bash
 code .
 ```
 
 vscode上で ` Shift + Ctrl + p` でパネルを開き、下記を検索する
-```
+```txt
 Dev container attach
 ```
 
@@ -86,25 +86,25 @@ Dev container attach
 
 ### 6. npm install
 
-```
+```bash
 npm install
 ```
 
 ### 7. マイグレーション
 
-```
+```bash
 php artisan migrate
 ```
 
 必要に応じて、seederを利用
 
-```
+```bash
 php artisan db:seed
 ```
 
 ### 8. Vite 開発サーバを起動
 
-```
+```bash
 npm run dev
 ```
 
@@ -117,13 +117,22 @@ http://localhost/
 ### 10. 静的解析の確認
 
 ルートディレクトリで下記を実施
-```
+```bash
 ./vendor/bin/phpstan analyse
 ```
 または、
-```
+```bash
 npm run larastan
 ```
+
+## 機能テスト
+
+機能テストを実施する際は下記で確認してからテストを行う
+```bash
+npm run test:php
+```
+上記コマンドは失敗やエラー時にすぐテストを終了するようにしてある
+（失敗時などに処理が止まらなくなる場合があるため）
 
 ## トラブルシューティング
 

--- a/README.md
+++ b/README.md
@@ -124,3 +124,18 @@ http://localhost/
 ```
 npm run larastan
 ```
+
+## トラブルシューティング
+
+### Target class [packages\***] does not exist.
+
+```
+Target class [packages\Recipe\UseCase\RecipeUseCase] does not exist.
+```
+
+`packages`ディレクトリかオートローダーに読み込まれていない、可能性がある
+下記を実施する
+```bash
+composer dump-autoload
+```
+

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -14,6 +14,15 @@ class UserSeeder extends Seeder
      */
     public function run(): void
     {
-        User::factory()->create();
+        $fix_email = 'test_user@example.com';
+        if (User::where('email', $fix_email)->exists()) {
+            User::factory()->create();
+        } else {
+            // fix_emailのUserがない場合はfix_emailのUserを作成
+            User::factory()->create([
+                'name' => 'test_名前',
+                'email' => $fix_email
+            ]);
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
         "lint": "eslint ./resources",
         "lint:debug": "eslint ./resources --debug",
         "lint:fix": "eslint ./resources --fix",
-        "larastan": "./vendor/bin/phpstan analyse"
+        "larastan": "./vendor/bin/phpstan analyse",
+        "test:php": "vendor/bin/phpunit --stop-on-failure"
     },
     "devDependencies": {
         "@angular-eslint/template-parser": "^17.1.1",

--- a/resources/views/recipes/index.blade.php
+++ b/resources/views/recipes/index.blade.php
@@ -98,7 +98,7 @@
                 @foreach ($response_dto->getRecipes() as $recipe)
                     <x-recipe-card :name="$recipe->getName()" :ingredient="$recipe->getIngredient()" :tags="$recipe->getTags()" :
                         width="max-md:flex-auto md:w-80 mx-4" date_label="前回作成日"
-                        date="{{ $recipe->getLastMakeDate() ?? {{ __('messages.not_made') }} }}" class="my-2" />
+                        date="{{ $recipe->getLastMakeDate() ?? __('messages.not_made') }}" class="my-2" />
                 @endforeach
             </div>
 


### PR DESCRIPTION
## 概要

- #31 
  - `resources/views/recipes/index.blade.php`の言語ファイルの読み込み修正
- readmeの修正
  - トラブルシューティング追加
  - テスト実施方法の追記
- `UserSeeder`の修正
  - 固定のユーザーがいない場合、固定のユーザーを作成するように修正
  - 固定のユーザーを作成すると、`db refresh`した際もログインが楽
- テストが失敗した際にテストを中止するコマンドを`package.json`に追加
  - 失敗やエラーが出た際に、かなり処理が重くなるため、基本はこちらを実施する
  - `vendor/bin/phpunit --stop-on-failure`
